### PR TITLE
Added automatic AP mode to main.py, also start telnet and ftp

### DIFF
--- a/MicroPython_BUILD/components/internalfs_image/image/main.py
+++ b/MicroPython_BUILD/components/internalfs_image/image/main.py
@@ -32,3 +32,17 @@ if tmo > 0:
         t = rtc.now()
         utime.strftime("%c")
         print("")
+
+if tmo == 0:
+    sta_if = network.WLAN(network.AP_IF)
+    sta_if.active(True)
+    print("WiFi started in AP mode")
+    utime.sleep_ms(100)
+    print(sta_if.ifconfig())
+
+network.telnet.start()
+utime.sleep_ms(500)
+print ("Telnet Started ",network.telnet.status())
+network.ftp.start()
+utime.sleep_ms(500)
+print ("FTP Started ",network.ftp.status())


### PR DESCRIPTION
This will put the network in AP mode if it did NOT login to a router. I would like to add the ability to try mutable networks ( so that the module can be worked on at home, work, school, friends house, etc ). Since this will put the module in AP mode you can thus always get to the board and reconfigure main.py via FTP!

This is also my first ever pull request. Please correct me if I did not do something right or need to follow a style etc.