### PR TITLE
Various typos

### DIFF
--- a/MicroPython_BUILD/BUILD.sh
+++ b/MicroPython_BUILD/BUILD.sh
@@ -37,8 +37,8 @@
 #   -a <app_size>  | --appsize=<app_size>         - declare the size of application partition in KB
 #                                                   default: auto detect needed size
 #                                                   the actual size will be 128 KB smaller then the declared size
-#   -p <comm_port> | --port=<comm_port>           - overwritte configured comm port, use the specified instead
-#   -b <bdrate>    | --bdrate=<bdrate>            - overwritte configured baud rate, use the specified instead
+#   -p <comm_port> | --port=<comm_port>           - overwrite configured comm port, use the specified instead
+#   -b <bdrate>    | --bdrate=<bdrate>            - overwrite configured baud rate, use the specified instead
 
 # Note:
 #   Multiple options and commands can be given

--- a/MicroPython_BUILD/build_func.sh
+++ b/MicroPython_BUILD/build_func.sh
@@ -361,9 +361,9 @@ check_Environment() {
 
 
     cd Tools
-    # -----------------------------------------
-    # _psram directories are not needed anymore
-    # -----------------------------------------
+    # ------------------------------------------
+    # _psram directories are not needed any more
+    # ------------------------------------------
     if [ -d "esp-idf_psram" ]; then
         rm -rf esp-idf_psram/ > /dev/null 2>&1
         rmdir esp-idf_psram > /dev/null 2>&1

--- a/MicroPython_BUILD/components/internalfs_image/image/examples/tftdemo.py
+++ b/MicroPython_BUILD/components/internalfs_image/image/examples/tftdemo.py
@@ -1,5 +1,5 @@
 """
-Demo program demonstrating the capabities of the MicroPython display module
+Demo program demonstrating the capabilities of the MicroPython display module
 Author:	LoBo (https://github/loboris)
 Date:	08/10/2017
 

--- a/MicroPython_BUILD/components/internalfs_image/image/examples/thread_example.py
+++ b/MicroPython_BUILD/components/internalfs_image/image/examples/thread_example.py
@@ -138,7 +138,7 @@ utime.sleep(1)
 machine.heap_info()
 _thread.list()
 
-# Set neopixel brightnes (%)
+# Set neopixel brightness (%)
 #_thread.notify(npth, 20)
 # Get counter value from Neopixel thread
 #_thread.notify(npth, 1000)

--- a/MicroPython_BUILD/components/internalfs_image/image/lib/controller_esp.py
+++ b/MicroPython_BUILD/components/internalfs_image/image/lib/controller_esp.py
@@ -146,7 +146,7 @@ class Controller(controller.Controller):
                 pin_ss.low()
 
                 spi.write(bytes([address])) # write register address
-                spi.write_readinto(bytes([value]), response) # write or read register walue
+                spi.write_readinto(bytes([value]), response) # write or read register value
                 #spi.write_readinto(bytes([address]), response)
 
                 pin_ss.high()

--- a/MicroPython_BUILD/components/micropython/README.md
+++ b/MicroPython_BUILD/components/micropython/README.md
@@ -5,7 +5,7 @@
 
 **MicroPython core** is synchronized with [main MicroPython repository](https://github.com/micropython/micropython)
 
-**Commit:** bcfff4fc98a73c5ad9b7d3e338649955e861ada4
+**Commit:** [bcfff4fc98a73c5ad9b7d3e338649955e861ada4](https://github.com/micropython/micropython/commit/bcfff4fc98a73c5ad9b7d3e338649955e861ada4)
 
 <br>
 

--- a/MicroPython_BUILD/components/micropython/esp32/libs/ftp.c
+++ b/MicroPython_BUILD/components/micropython/esp32/libs/ftp.c
@@ -1173,7 +1173,7 @@ int ftp_run (uint32_t elapsed)
                     ftp_data.loggin.passvalid = false;
                     strcpy (ftp_path, "/");
                     ESP_LOGI(FTP_TAG, "Connected.");
-                    ftp_send_reply (220, "Micropython FTP Server");
+                    ftp_send_reply (220, "MicroPython FTP Server");
                     break;
                 }
             }

--- a/MicroPython_BUILD/components/micropython/esp32/libs/tft/tft.c
+++ b/MicroPython_BUILD/components/micropython/esp32/libs/tft/tft.c
@@ -234,7 +234,7 @@ void TFT_drawFastHLine(int16_t x, int16_t y, int16_t w, color_t color) {
 }
 
 // Bresenham's algorithm - thx wikipedia - speed enhanced by Bodmer this uses
-// the eficient FastH/V Line draw routine for segments of 2 pixels or more
+// the efficient FastH/V Line draw routine for segments of 2 pixels or more
 //----------------------------------------------------------------------------------
 static void _drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1, color_t color)
 {
@@ -2304,7 +2304,7 @@ static UINT tjd_input (
 	// Device identifier for the session (5th argument of jd_prepare function)
 	JPGIODEV *dev = (JPGIODEV*)jd->device;
 
-	if (buff) {	// Read nd bytes from the input strem
+	if (buff) {	// Read nd bytes from the input stream
 		rb = fread(buff, 1, nd, dev->fhndl);
 		return rb;	// Returns actual number of bytes read
 	}
@@ -2329,7 +2329,7 @@ static UINT tjd_buf_input (
 
 	if ((dev->bufptr + nd) > (dev->bufsize + 2)) nd = (dev->bufsize + 2) - dev->bufptr;
 
-	if (buff) {	// Read nd bytes from the input strem
+	if (buff) {	// Read nd bytes from the input stream
 		memcpy(buff, dev->membuff + dev->bufptr, nd);
 		dev->bufptr += nd;
 		return nd;	// Returns number of bytes read

--- a/MicroPython_BUILD/components/micropython/esp32/libs/tft/tft.h
+++ b/MicroPython_BUILD/components/micropython/esp32/libs/tft/tft.h
@@ -185,9 +185,9 @@ extern const color_t TFT_PINK;
  *       x: horizontal position
  *       y: vertical position
  *   color: pixel color
- *     sel: if not 0 activate CS before and deactivat after sending pixel data to display
+ *     sel: if not 0 activate CS before and deactivate after sending pixel data to display
  *          when sending multiple pixels it is faster to activate the CS first,
- *          send all pixels an deactivate CS after all pixela was sent
+ *          send all pixels and deactivate CS after all pixels have been sent
 */
 //-------------------------------------------------------------------
 void TFT_drawPixel(int16_t x, int16_t y, color_t color, uint8_t sel);
@@ -246,7 +246,7 @@ void TFT_drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1, color_t color)
 
 /*
  * Draw line on screen from (x,y) point at given angle
- * Line drawing angle starts at lower right quadrant of the screen and is offseted by
+ * Line drawing angle starts at lower right quadrant of the screen and is offset by
  * '_angleOffset' global variable (default: -90 degrees)
  *
  * Params:
@@ -429,7 +429,7 @@ void TFT_fillEllipse(uint16_t x0, uint16_t y0, uint16_t rx, uint16_t ry, color_t
 
 /*
  * Draw circle arc on screen
- * Arc drawing angle starts at lower right quadrant of the screen and is offseted by
+ * Arc drawing angle starts at lower right quadrant of the screen and is offset by
  * '_angleOffset' global variable (default: -90 degrees)
  *
  * Params:
@@ -477,7 +477,7 @@ void TFT_drawPolygon(int cx, int cy, int sides, int diameter, color_t color, col
  *
  * Params:
  *			 font: font number; use defined font names
- *		font_file: pointer to font file name; NULL for embeded fonts
+ *		font_file: pointer to font file name; NULL for embedded fonts
  */
 //----------------------------------------------------
 void TFT_setFont(uint8_t font, const char *font_file);
@@ -531,7 +531,7 @@ int TFT_getfontheight();
 void TFT_print(char *st, int x, int y);
 
 /*
- * Set atributes for 7 segment vector font
+ * Set attributes for 7 segment vector font
  * == 7 segment font must be the current font to this function to have effect ==
  *
  * Params:

--- a/MicroPython_BUILD/components/micropython/esp32/machine_pin.c
+++ b/MicroPython_BUILD/components/micropython/esp32/machine_pin.c
@@ -233,7 +233,7 @@ STATIC void machine_pin_print(const mp_print_t *print, mp_obj_t self_in, mp_prin
         else if (pin_irq_type == GPIO_INTR_LOW_LEVEL) sprintf(sirq, "IRQ_LOLEVEL");
         else if (pin_irq_type == GPIO_INTR_HIGH_LEVEL) sprintf(sirq, "IRQ_HILEVEL");
         else sprintf(sirq, "Unknown");
-    	mp_printf(print, ", irq=%s, debounce=%u, actTimel=%d", sirq, self->irq_debounce, self->irq_active_time);
+    	mp_printf(print, ", irq=%s, debounce=%u, actTime=%d", sirq, self->irq_debounce, self->irq_active_time);
     }
 }
 

--- a/MicroPython_BUILD/components/micropython/esp32/modules/ak8963.py
+++ b/MicroPython_BUILD/components/micropython/esp32/modules/ak8963.py
@@ -64,14 +64,14 @@ class AK8963:
         if 0x48 != self.whoami:
             raise RuntimeError("AK8963 not found in I2C bus.")
 
-        # Sensitivity adjustement values
+        # Sensitivity adjustment values
         self._register_char(_CNTL1, _MODE_FUSE_ROM_ACCESS)
         asax = self._register_char(_ASAX)
         asay = self._register_char(_ASAY)
         asaz = self._register_char(_ASAZ)
         self._register_char(_CNTL1, _MODE_POWER_DOWN)
 
-        # Should wait atleast 100us before next mode
+        # Should wait at least 100us before next mode
         self._adjustement = (
             (0.5 * (asax - 128)) / 128 + 1,
             (0.5 * (asay - 128)) / 128 + 1,
@@ -94,7 +94,7 @@ class AK8963:
         xyz = list(self._register_three_shorts(_HXL))
         self._register_char(_ST2) # Enable updating readings again
 
-        # Apply factory axial sensitivy adjustements
+        # Apply factory axial sensitivity adjustments
         xyz[0] *= self._adjustement[0]
         xyz[1] *= self._adjustement[1]
         xyz[2] *= self._adjustement[2]

--- a/MicroPython_BUILD/components/micropython/esp32/modules/microWebSrv.py
+++ b/MicroPython_BUILD/components/micropython/esp32/modules/microWebSrv.py
@@ -181,7 +181,7 @@ class MicroWebSrv :
         self._started       = False
         self.thID           = None
         self.isThreaded     = False
-        self._state         = "Stoped"
+        self._state         = "Stopped"
 
         self.MaxWebSocketRecvLen     = 1024
         self.WebSocketThreaded       = True
@@ -236,7 +236,7 @@ class MicroWebSrv :
                 break
             self._client(self, client, cliAddr)
         self._started = False
-        self._state = "Stoped"
+        self._state = "Stopped"
         self.thID = None
 
     # ============================================================================
@@ -870,7 +870,7 @@ class MicroWebSrv :
                   'The server cannot process the request due to a high load'),
             504: ('Gateway Timeout',
                   'The gateway server did not receive a timely response'),
-            505: ('HTTP Version Not Supported', 'Cannot fulfill request.'),
+            505: ('HTTP Version Not Supported', 'Cannot fulfil request.'),
         }
 
     # ============================================================================

--- a/MicroPython_BUILD/components/micropython/esp32/modules/mpu6500.py
+++ b/MicroPython_BUILD/components/micropython/esp32/modules/mpu6500.py
@@ -63,7 +63,7 @@ _GYRO_SO_500DPS = 62.5
 _GYRO_SO_1000DPS = 32.8
 _GYRO_SO_2000DPS = 16.4
 
-# Used for enablind and disabling the i2c bypass access
+# Used for enabling and disabling the i2c bypass access
 _I2C_BYPASS_MASK = const(0b00000010)
 _I2C_BYPASS_EN = const(0b00000010)
 _I2C_BYPASS_DIS = const(0b00000000)

--- a/MicroPython_BUILD/components/micropython/esp32/modules/tpcalib.py
+++ b/MicroPython_BUILD/components/micropython/esp32/modules/tpcalib.py
@@ -1,4 +1,4 @@
-# Touch pannel calibration for ILI9341 based displays
+# Touch panel calibration for ILI9341 based displays
 
 
 import display, math, machine, utime

--- a/MicroPython_BUILD/components/micropython/esp32/modules_examples/drivers/ak8963.py
+++ b/MicroPython_BUILD/components/micropython/esp32/modules_examples/drivers/ak8963.py
@@ -64,14 +64,14 @@ class AK8963:
         if 0x48 != self.whoami:
             raise RuntimeError("AK8963 not found in I2C bus.")
 
-        # Sensitivity adjustement values
+        # Sensitivity adjustment values
         self._register_char(_CNTL1, _MODE_FUSE_ROM_ACCESS)
         asax = self._register_char(_ASAX)
         asay = self._register_char(_ASAY)
         asaz = self._register_char(_ASAZ)
         self._register_char(_CNTL1, _MODE_POWER_DOWN)
 
-        # Should wait atleast 100us before next mode
+        # Should wait at least 100us before next mode
         self._adjustement = (
             (0.5 * (asax - 128)) / 128 + 1,
             (0.5 * (asay - 128)) / 128 + 1,
@@ -94,7 +94,7 @@ class AK8963:
         xyz = list(self._register_three_shorts(_HXL))
         self._register_char(_ST2) # Enable updating readings again
 
-        # Apply factory axial sensitivy adjustements
+        # Apply factory axial sensitivity adjustments
         xyz[0] *= self._adjustement[0]
         xyz[1] *= self._adjustement[1]
         xyz[2] *= self._adjustement[2]

--- a/MicroPython_BUILD/components/micropython/esp32/modules_examples/drivers/mpu6500.py
+++ b/MicroPython_BUILD/components/micropython/esp32/modules_examples/drivers/mpu6500.py
@@ -63,7 +63,7 @@ _GYRO_SO_500DPS = 62.5
 _GYRO_SO_1000DPS = 32.8
 _GYRO_SO_2000DPS = 16.4
 
-# Used for enablind and disabling the i2c bypass access
+# Used for enabling and disabling the i2c bypass access
 _I2C_BYPASS_MASK = const(0b00000010)
 _I2C_BYPASS_EN = const(0b00000010)
 _I2C_BYPASS_DIS = const(0b00000000)

--- a/MicroPython_BUILD/components/micropython/esp32/modules_examples/lora/controller_esp.py
+++ b/MicroPython_BUILD/components/micropython/esp32/modules_examples/lora/controller_esp.py
@@ -146,7 +146,7 @@ class Controller(controller.Controller):
                 pin_ss.low()
 
                 spi.write(bytes([address])) # write register address
-                spi.write_readinto(bytes([value]), response) # write or read register walue
+                spi.write_readinto(bytes([value]), response) # write or read register value
                 #spi.write_readinto(bytes([address]), response)
 
                 pin_ss.high()

--- a/MicroPython_BUILD/components/micropython/esp32/modules_examples/lora/sx127x.py
+++ b/MicroPython_BUILD/components/micropython/esp32/modules_examples/lora/sx127x.py
@@ -130,7 +130,7 @@ class SX127x:
         self.standby()
         self.implicitHeaderMode(implicitHeaderMode)
 
-        # reset FIFO address and paload length
+        # reset FIFO address and payload length
         self.writeRegister(REG_FIFO_ADDR_PTR, FifoTxBaseAddr)
         self.writeRegister(REG_PAYLOAD_LENGTH, 0)
 

--- a/MicroPython_BUILD/components/micropython/esp32/modules_examples/mqtt_example.py
+++ b/MicroPython_BUILD/components/micropython/esp32/modules_examples/mqtt_example.py
@@ -33,7 +33,7 @@ mqtt.start()
 # Wait until status is: (1, 'Connected')
 
 mqtt.subscribe('test')
-mqtt.publish('test', 'Hi from Micropython')
+mqtt.publish('test', 'Hi from MicroPython')
 
 mqtt.stop()
 

--- a/MicroPython_BUILD/components/micropython/esp32/modules_examples/tft/paint.py
+++ b/MicroPython_BUILD/components/micropython/esp32/modules_examples/tft/paint.py
@@ -10,7 +10,7 @@ p = paint.Paint(tft)
 To run the program:
   execute: 'p.start()' to start the program
   or
-  execute: 'p.start(tft.LANDSCAPE)' to set the orientation andstart the program
+  execute: 'p.start(tft.LANDSCAPE)' to set the orientation and start the program
 
 Program can also be run in the thread:
   'paint_th = _thread.start("Paint", p.start, ())'

--- a/MicroPython_BUILD/components/micropython/esp32/modules_examples/tft/tftdemo.py
+++ b/MicroPython_BUILD/components/micropython/esp32/modules_examples/tft/tftdemo.py
@@ -303,7 +303,7 @@ def roundrectDemo(sec=5, dofill=False):
             break
     tft.resetwin()
 
-# Fisplay all demos
+# Display all demos
 #--------------------------------------
 def fullDemo(sec=5, rot=tft.LANDSCAPE):
     tft.orient(rot)

--- a/MicroPython_BUILD/components/micropython/esp32/modules_examples/tft/tftdemo.py
+++ b/MicroPython_BUILD/components/micropython/esp32/modules_examples/tft/tftdemo.py
@@ -1,5 +1,5 @@
 """
-Demo program demonstrating the capabities of the MicroPython display module
+Demo program demonstrating the capabilities of the MicroPython display module
 Author:	LoBo (https://github/loboris)
 Date:	08/10/2017
 

--- a/MicroPython_BUILD/components/micropython/esp32/modules_examples/thread_example.py
+++ b/MicroPython_BUILD/components/micropython/esp32/modules_examples/thread_example.py
@@ -161,7 +161,7 @@ utime.sleep(1)
 machine.heap_info()
 _thread.list()
 
-# Set neopixel brightnes (%)
+# Set neopixel brightness (%)
 #_thread.notify(npth, 20)
 # Get counter value from Neopixel thread
 #_thread.notify(npth, 1000)

--- a/MicroPython_BUILD/components/micropython/esp32/modules_examples/webserver/webserver_example.py
+++ b/MicroPython_BUILD/components/micropython/esp32/modules_examples/webserver/webserver_example.py
@@ -158,13 +158,13 @@ srv.WebSocketThreaded       = ws_run_in_thread
 #    For this example 4096 should be enough, for more complex
 #    webSocket handling you may need to increase this size
 # If WebSocketS is NOT running in thread, and WebServer IS running in thread
-# make shure WebServer has enough stack size to handle also the WebSocket requests
+# make sure WebServer has enough stack size to handle also the WebSocket requests
 srv.WebSocketStackSize      = 4096
 srv.AcceptWebSocketCallback = _acceptWebSocketCallback
 # ------------------------------------------------------
 
 # If WebSocketS used and NOT running in thread, and WebServer IS running in thread
-# make shure WebServer has enough stack size to handle also the WebSocket requests
+# make sure WebServer has enough stack size to handle also the WebSocket requests
 srv.Start(threaded=srv_run_in_thread, stackSize=8192)
 
 # ----------------------------------------------------------------------------

--- a/MicroPython_BUILD/components/micropython/esp32/modymodem.c
+++ b/MicroPython_BUILD/components/micropython/esp32/modymodem.c
@@ -526,7 +526,7 @@ int Ymodem_Transmit (char* sendFileName, unsigned int sizeFile, FILE *ffd, char 
   /* When the receiving program receives this block and successfully
    * opened the output file, it shall acknowledge this block with an ACK
    * character and then proceed with a normal YMODEM file transfer
-   * beginning with a "C" or NAK tranmsitted by the receiver.
+   * beginning with a "C" or NAK transmitted by the receiver.
    */
   Ymodem_PrepareIntialPacket(packet_data, sendFileName, sizeFile);
   do 

--- a/MicroPython_BUILD/components/micropython/esp32/mpconfigport.h
+++ b/MicroPython_BUILD/components/micropython/esp32/mpconfigport.h
@@ -251,10 +251,10 @@
 #define mp_type_textio                      nativefs_type_textio
 
 // internal flash file system configuration
-#ifdef CONFIG_MICROPY_INTERNALFS_ENCRIPTED
-#define MICROPY_INTERNALFS_ENCRIPTED        (1)	// use encription on filesystem (UNTESTED!)
+#ifdef CONFIG_MICROPY_INTERNALFS_ENCRYPTED
+#define MICROPY_INTERNALFS_ENCRYPTED        (1)	// use encryption on filesystem (UNTESTED!)
 #else
-#define MICROPY_INTERNALFS_ENCRIPTED        (0) // do not use encription on filesystem
+#define MICROPY_INTERNALFS_ENCRYPTED        (0) // do not use encryption on filesystem
 #endif
 
 // === sdcard using ESP32 sdmmc driver configuration ===

--- a/MicroPython_BUILD/components/micropython/esp32/mphalport.c
+++ b/MicroPython_BUILD/components/micropython/esp32/mphalport.c
@@ -335,7 +335,7 @@ uint64_t mp_hal_ticks_us(void) {
 }
 
 /*
- * Delay specified number of milli seconds
+ * Delay specified number of milliseconds
  * For the delay time up to 10 ms the function is blocking
  * For delay times greater than 10 ms, the function
  * does not block the execution of the other threads.

--- a/MicroPython_BUILD/components/mkfatfs/src/idf/orig/wear_levelling/WL_Flash.cpp
+++ b/MicroPython_BUILD/components/mkfatfs/src/idf/orig/wear_levelling/WL_Flash.cpp
@@ -113,7 +113,7 @@ esp_err_t WL_Flash::init()
     WL_RESULT_CHECK(result);
 
     int check_size = sizeof(wl_state_t) - sizeof(uint32_t);
-    // Chech CRC and recover state
+    // Check CRC and recover state
     uint32_t crc1 = crc32::crc32_le(WL_CFG_CRC_CONST, (uint8_t *)&this->state, check_size);
     uint32_t crc2 = crc32::crc32_le(WL_CFG_CRC_CONST, (uint8_t *)state_copy, check_size);
 

--- a/MicroPython_BUILD/components/mklittlefs/littlefs/lfs.h
+++ b/MicroPython_BUILD/components/mklittlefs/littlefs/lfs.h
@@ -102,7 +102,7 @@ enum lfs_open_flags {
     LFS_F_DIRTY   = 0x10000, // File does not match storage
     LFS_F_WRITING = 0x20000, // File has been written since last flush
     LFS_F_READING = 0x40000, // File has been read since last flush
-    LFS_F_ERRED   = 0x80000, // An error occured during write
+    LFS_F_ERRED   = 0x80000, // An error occurred during write
 };
 
 // File seek flags
@@ -119,25 +119,25 @@ struct lfs_config {
     // information to the block device operations
     void *context;
 
-    // Read a region in a block. Negative error codes are propogated
+    // Read a region in a block. Negative error codes are propagated
     // to the user.
     int (*read)(const struct lfs_config *c, lfs_block_t block,
             lfs_off_t off, void *buffer, lfs_size_t size);
 
     // Program a region in a block. The block must have previously
-    // been erased. Negative error codes are propogated to the user.
+    // been erased. Negative error codes are propagated to the user.
     // May return LFS_ERR_CORRUPT if the block should be considered bad.
     int (*prog)(const struct lfs_config *c, lfs_block_t block,
             lfs_off_t off, const void *buffer, lfs_size_t size);
 
     // Erase a block. A block must be erased before being programmed.
     // The state of an erased block is undefined. Negative error codes
-    // are propogated to the user.
+    // are propagated to the user.
     // May return LFS_ERR_CORRUPT if the block should be considered bad.
     int (*erase)(const struct lfs_config *c, lfs_block_t block);
 
     // Sync the state of the underlying block device. Negative error codes
-    // are propogated to the user.
+    // are propagated to the user.
     int (*sync)(const struct lfs_config *c);
 
     // Minimum size of a block read. This determines the size of read buffers.
@@ -475,7 +475,7 @@ int lfs_dir_rewind(lfs_t *lfs, lfs_dir_t *dir);
 // Returns a negative error code on failure.
 int lfs_traverse(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data);
 
-// Prunes any recoverable errors that may have occured in the filesystem
+// Prunes any recoverable errors that may have occurred in the filesystem
 //
 // Not needed to be called by user unless an operation is interrupted
 // but the filesystem is still mounted. This is already called on first

--- a/MicroPython_BUILD/components/mklittlefs/mklfs.c
+++ b/MicroPython_BUILD/components/mklittlefs/mklfs.c
@@ -105,7 +105,7 @@ int addFile(char* name, const char* path)
 
     lfs_file_t *file = (lfs_file_t *) malloc(sizeof(lfs_file_t));
     if (file == NULL) {
-        printf("error: failed to open lfs file '%s' for writting\r\n", name);
+        printf("error: failed to open lfs file '%s' for writing\r\n", name);
         return 2;
     }
 
@@ -308,7 +308,7 @@ int lfs_img_mount(void)
 
     err = lfs_format(&lfs, &config);
     if (err) {
-        printf("Error formating image (%d)\r\n", err);
+        printf("Error formatting image (%d)\r\n", err);
         return err;
     }
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Currently, there are several modules & development boards which incorporates **4
 * **WiPy 3.0** _board_ from [Pycom](https://pycom.io/product/wipy-3/).
 * **TTGO TAudio** _board_ ([eBay](https://www.ebay.com/itm/TTGO-TAudio-V1-0-ESP32-WROVER-SD-Card-Slot-Bluetooth-WI-FI-Module-MPU9250/152835010520?hash=item2395ad2fd8:g:Jt8AAOSwR2RaOdEp))
 * **Lolin32 Pro** _board_ from [Wemos](https://wiki.wemos.cc/products:lolin32:lolin32_pro) - **`no longer available`** ([Schematic](https://wiki.wemos.cc/_media/products:lolin32:sch_lolin32_pro_v1.0.0.pdf)).
+* **Lolin D32 Pro** _board_ from [Wemos](https://wiki.wemos.cc/products:d32:d32_pro) available on [AliExpress](https://www.aliexpress.com/store/product/LOLIN-D32-Pro-V2-0-0-wifi-bluetooth-board-based-ESP-32-esp32-Rev1-ESP32-WROVER/1331105_32883116057.html)
 * **ESP-WROVER** _module_ from Espressif, available from [ElectroDragon](http://www.electrodragon.com/product/esp32-wrover-v4-module-based-esp32/) and many other vendors.
 * **ALB32-WROVER** _module_ (4 MB SPIRAM & 4/8/16 MB Flash) from [AnalogLamb](https://www.analoglamb.com/product/alb32-wrover-esp32-module-with-64mb-flash-and-32mb-psram/).
 * **S01**, **L01** and **G01** _OEM modules_ from [Pycom](https://pycom.io/webshop#oem-products).

--- a/README.md
+++ b/README.md
@@ -50,17 +50,17 @@ This way many features not available in standard ESP32 MicroPython are enabled, 
 
 ### Features
 
-* MicroPython core based on latest build from [main Micropython repository](https://github.com/micropython/micropython)
+* MicroPython core based on latest build from [main MicroPython repository](https://github.com/micropython/micropython)
 * added changes needed to build for ESP32 with psRAM
 * Default configuration has **2MB** of MicroPython heap, **20KB** of MicroPython stack, **~200KB** of free DRAM heap for C modules and functions
 * MicroPython can be built in **unicore** (FreeRTOS & MicroPython task running only on the first ESP32 core, or **dualcore** configuration (MicroPython task running on ESP32 **App** core)
 * ESP32 Flash can be configured in any mode, **QIO**, **QOUT**, **DIO**, **DOUT**
 * **BUILD.sh** script is provided to make **building** MicroPython firmware as **easy** as possible
-* Internal Fat filesystem is built with esp-idf **wear leveling** driver, so there is less danger of damaging the flash with frequent writes.
+* Internal Fat filesystem is built with esp-idf **wear levelling** driver, so there is less danger of damaging the flash with frequent writes.
 * **SPIFFS** filesystem is supported and can be used instead of FatFS in SPI Flash. Configurable via **menuconfig**
 * Flexible automatic and/or manual filesystem configuration
-* **sdcard** support is included which uses esp-idf **sdmmc** driver and can work in **SD mode** (*1-bit* and *4-bit*) or in **SPI mode** (sd card can be connected to any pins). For imformation on how to connect sdcard see the documentation.
-* Files **timestamp** is correctly set to system time both on internal fat filesysten and on sdcard
+* **sdcard** support is included which uses esp-idf **sdmmc** driver and can work in **SD mode** (*1-bit* and *4-bit*) or in **SPI mode** (sd card can be connected to any pins). For information on how to connect sdcard see the documentation.
+* Files **timestamp** is correctly set to system time both on internal fat filesystem and on sdcard
 * **Native ESP32 VFS** support for spi Flash & sdcard filesystems.
 * **RTC Class** is added to machine module, including methods for synchronization of system time to **ntp** server, **deepsleep**, **wakeup** from deepsleep **on external pin** level, ...
 * **Time zone** can be configured via **menuconfig** and is used when syncronizing time from NTP server


### PR DESCRIPTION
In `MicroPython_BUILD/components/micropython/esp32/mpconfigport.h` there is a definition `MICROPY_INTERNALFS_ENCRIPTED` which I changed to `MICROPY_INTERNALFS_ENCRYPTED`.

`ENCRIPTED` -> `ENCRYPTED`

I couldn't find any other references to the definition.