### PR TITLE
Restore original prototype of `mp_sched_schedule`

### DIFF
--- a/MicroPython_BUILD/components/micropython/esp32/machine_adc.c
+++ b/MicroPython_BUILD/components/micropython/esp32/machine_adc.c
@@ -218,7 +218,7 @@ static void adc_task(void *pvParameters)
         if (buff16) free(buff16);
     }
 
-    if (self->callback) mp_sched_schedule(self->callback, self, NULL);
+    if (self->callback) mp_sched_schedule_ex(self->callback, self, NULL);
 
 exit:
     // i2s cleanup
@@ -302,7 +302,7 @@ STATIC void adc_timer_isr(void *self_in)
             adc_timer_handle = NULL;
         }
         collect_end_time = esp_timer_get_time(); //mp_hal_ticks_us();
-        if (self->callback) mp_sched_schedule(self->callback, self, NULL);
+        if (self->callback) mp_sched_schedule_ex(self->callback, self, NULL);
         self->buffer = NULL;
         adc_timer_active = false;
         collect_active = false;

--- a/MicroPython_BUILD/components/micropython/esp32/machine_hw_i2c.c
+++ b/MicroPython_BUILD/components/micropython/esp32/machine_hw_i2c.c
@@ -242,7 +242,7 @@ STATIC void _sched_callback(mp_obj_t function, int cbtype, int addr, int len, in
     else {
         if (!make_carg_entry(carg, 4, MP_SCHED_ENTRY_TYPE_NONE, 0, NULL, NULL)) return;
     }
-    mp_sched_schedule(function, mp_const_none, carg);
+    mp_sched_schedule_ex(function, mp_const_none, carg);
 }
 
 //--------------------------------------------

--- a/MicroPython_BUILD/components/micropython/esp32/machine_pin.c
+++ b/MicroPython_BUILD/components/micropython/esp32/machine_pin.c
@@ -162,7 +162,7 @@ static void debounce_task(void *pvParameters)
                 self->irq_retvalue = levl;
                 if (self->irq_handler) {
                     // schedule the callback function
-                    mp_sched_schedule(self->irq_handler, MP_OBJ_FROM_PTR(self), NULL);
+                    mp_sched_schedule_ex(self->irq_handler, MP_OBJ_FROM_PTR(self), NULL);
                 }
                 break;
             }
@@ -183,7 +183,7 @@ static void debounce_task(void *pvParameters)
 	if (self->irq_handler) {
 		// schedule the callback function
         self->irq_retvalue = gpio_get_level(self->id);
-		mp_sched_schedule(self->irq_handler, MP_OBJ_FROM_PTR(self), NULL);
+		mp_sched_schedule_ex(self->irq_handler, MP_OBJ_FROM_PTR(self), NULL);
 	}
 
 	// Re-enable interrupt ONLY for edge types
@@ -213,7 +213,7 @@ STATIC void machine_pin_isr_handler(void *arg)
         if (self->irq_handler) {
             // schedule the callback function
             self->irq_retvalue = gpio_get_level(self->id);
-            mp_sched_schedule(self->irq_handler, MP_OBJ_FROM_PTR(self), NULL);
+            mp_sched_schedule_ex(self->irq_handler, MP_OBJ_FROM_PTR(self), NULL);
         }
 
         // Re-enable interrupt ONLY for edge types

--- a/MicroPython_BUILD/components/micropython/esp32/machine_timer.c
+++ b/MicroPython_BUILD/components/micropython/esp32/machine_timer.c
@@ -208,7 +208,7 @@ STATIC void machine_timer_isr(void *self_in)
     }
     self->event_num++;
 
-    if ((self->callback) && (mp_sched_schedule(self->callback, self, NULL))) self->cb_num++;
+    if ((self->callback) && (mp_sched_schedule_ex(self->callback, self, NULL))) self->cb_num++;
 }
 
 //----------------------------------------------
@@ -235,7 +235,7 @@ STATIC void machine_ext_timer_isr(void *self_in)
 				    extmr->event_num++;
 					if (extmr->counter == extmr->alarm) {
 						// Schedule the callback execution
-						if ((extmr->callback) && (mp_sched_schedule(extmr->callback, extmr, NULL))) {
+						if ((extmr->callback) && (mp_sched_schedule_ex(extmr->callback, extmr, NULL))) {
 							extmr->cb_num++;
 							self->cb_num++;
 						}

--- a/MicroPython_BUILD/components/micropython/esp32/machine_uart.c
+++ b/MicroPython_BUILD/components/micropython/esp32/machine_uart.c
@@ -124,7 +124,7 @@ static void _sched_callback(mp_obj_t function, int uart, int type, int iarglen, 
 	else {
 		if (!make_carg_entry(carg, 2, MP_SCHED_ENTRY_TYPE_INT, iarglen, NULL, NULL)) return;
 	}
-	mp_sched_schedule(function, mp_const_none, carg);
+	mp_sched_schedule_ex(function, mp_const_none, carg);
 }
 
 //---------------------------------------------

--- a/MicroPython_BUILD/components/micropython/esp32/modmqtt.c
+++ b/MicroPython_BUILD/components/micropython/esp32/modmqtt.c
@@ -89,7 +89,7 @@ STATIC void connected_cb(mqtt_obj_t *self)
 		mp_sched_carg_t *carg = make_cargs(MP_SCHED_CTYPE_SINGLE);
 		if (!carg) return;
 		if (!make_carg_entry(carg, 0, MP_SCHED_ENTRY_TYPE_STR, strlen(self->name), (const uint8_t *)self->name, NULL)) return;
-		mp_sched_schedule(self->mpy_connected_cb, mp_const_none, carg);
+		mp_sched_schedule_ex(self->mpy_connected_cb, mp_const_none, carg);
     }
 }
 
@@ -100,7 +100,7 @@ STATIC void disconnected_cb(mqtt_obj_t *self)
 		mp_sched_carg_t *carg = make_cargs(MP_SCHED_CTYPE_SINGLE);
 		if (!carg) return;
 		if (!make_carg_entry(carg, 0, MP_SCHED_ENTRY_TYPE_STR, strlen(self->name), (const uint8_t *)self->name, NULL)) return;
-		mp_sched_schedule(self->mpy_disconnected_cb, mp_const_none, carg);
+		mp_sched_schedule_ex(self->mpy_disconnected_cb, mp_const_none, carg);
     }
 }
 
@@ -117,7 +117,7 @@ STATIC void subscribed_cb(mqtt_obj_t *self, const char *topic)
    		else {
    	   		if (!make_carg_entry(carg, 1, MP_SCHED_ENTRY_TYPE_STR, 1, (const uint8_t *)"?", NULL)) return;
    		}
-    	mp_sched_schedule(self->mpy_subscribed_cb, mp_const_none, carg);
+    	mp_sched_schedule_ex(self->mpy_subscribed_cb, mp_const_none, carg);
     }
 }
 
@@ -134,7 +134,7 @@ STATIC void unsubscribed_cb(mqtt_obj_t *self, const char *topic)
    		else {
    	   		if (!make_carg_entry(carg, 1, MP_SCHED_ENTRY_TYPE_STR, 1, (const uint8_t *)"?", NULL)) return;
    		}
-    	mp_sched_schedule(self->mpy_unsubscribed_cb, mp_const_none, carg);
+   		mp_sched_schedule_ex(self->mpy_unsubscribed_cb, mp_const_none, carg);
     }
 }
 
@@ -152,7 +152,7 @@ STATIC void published_cb(mqtt_obj_t *self, const char *topic, int type)
    	   		if (!make_carg_entry(carg, 1, MP_SCHED_ENTRY_TYPE_STR, 1, (const uint8_t *)"?", NULL)) return;
    		}
    		if (!make_carg_entry(carg, 2, MP_SCHED_ENTRY_TYPE_INT, type, NULL, NULL)) return;
-    	mp_sched_schedule(self->mpy_published_cb, mp_const_none, carg);
+   		mp_sched_schedule_ex(self->mpy_published_cb, mp_const_none, carg);
     }
 }
 
@@ -196,7 +196,7 @@ STATIC void data_cb(mqtt_obj_t *self, void *params)
 			if (!make_carg_entry(carg, 0, MP_SCHED_ENTRY_TYPE_STR, strlen(self->name), (const uint8_t *)self->name, NULL)) return;
 			if (!make_carg_entry(carg, 1, MP_SCHED_ENTRY_TYPE_STR, event->topic_len, (const uint8_t *)event->topic, NULL)) return;
 			if (!make_carg_entry(carg, 2, MP_SCHED_ENTRY_TYPE_STR, event->data_len, (const uint8_t *)event->data, NULL)) return;
-			mp_sched_schedule(self->mpy_data_cb, mp_const_none, carg);
+			mp_sched_schedule_ex(self->mpy_data_cb, mp_const_none, carg);
 		}
 	}
 	else {
@@ -212,7 +212,7 @@ STATIC void data_cb(mqtt_obj_t *self, void *params)
 				if (!make_carg_entry(carg, 0, MP_SCHED_ENTRY_TYPE_STR, strlen(self->name), (const uint8_t *)self->name, NULL)) goto freebufs;
 				if (!make_carg_entry(carg, 1, MP_SCHED_ENTRY_TYPE_STR, strlen((const char *)self->topicbuf), self->topicbuf, NULL)) goto freebufs;
 				if (!make_carg_entry(carg, 2, MP_SCHED_ENTRY_TYPE_STR, event->total_data_len, self->msgbuf, NULL)) goto freebufs;
-				mp_sched_schedule(self->mpy_data_cb, mp_const_none, carg);
+				mp_sched_schedule_ex(self->mpy_data_cb, mp_const_none, carg);
 freebufs:
 				// Free the buffers
 				free(self->msgbuf);

--- a/MicroPython_BUILD/components/micropython/esp32/modnetwork.c
+++ b/MicroPython_BUILD/components/micropython/esp32/modnetwork.c
@@ -215,7 +215,7 @@ static void processPROBEREQRECVED(const uint8_t *frame, int len, int rssi)
 		if (!make_carg_entry(carg, 1, MP_SCHED_ENTRY_TYPE_INT, len, NULL, "len")) goto end;
 		if (!make_carg_entry(carg, 2, MP_SCHED_ENTRY_TYPE_STR, len, frame, "frame")) goto end;
 
-		mp_sched_schedule(probereq_callback, mp_const_none, carg);
+		mp_sched_schedule_ex(probereq_callback, mp_const_none, carg);
 end:
 		if (probereq_mutex) xSemaphoreGive(probereq_mutex);
 	}
@@ -358,7 +358,7 @@ static void processEvent_callback(system_event_t *event)
 			// the 3rd tuple item was not added, add it now
 			if (!make_carg_entry(carg, 2, MP_SCHED_ENTRY_TYPE_NONE, 0, NULL, NULL)) return;
 		}
-		mp_sched_schedule(event_callback, mp_const_none, carg);
+		mp_sched_schedule_ex(event_callback, mp_const_none, carg);
 	}
 }
 

--- a/MicroPython_BUILD/components/micropython/py/modmicropython.c
+++ b/MicroPython_BUILD/components/micropython/py/modmicropython.c
@@ -150,7 +150,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_micropython_kbd_intr_obj, mp_micropython_kbd
 
 #if MICROPY_ENABLE_SCHEDULER
 STATIC mp_obj_t mp_micropython_schedule(mp_obj_t function, mp_obj_t arg) {
-    if (!mp_sched_schedule(function, arg, NULL)) {
+    if (!mp_sched_schedule_ex(function, arg, NULL)) {
         mp_raise_msg(&mp_type_RuntimeError, "schedule stack full");
     }
     return mp_const_none;

--- a/MicroPython_BUILD/components/micropython/py/runtime.h
+++ b/MicroPython_BUILD/components/micropython/py/runtime.h
@@ -108,7 +108,11 @@ void mp_handle_pending_tail(mp_uint_t atomic_state);
 void mp_sched_lock(void);
 void mp_sched_unlock(void);
 static inline unsigned int mp_sched_num_pending(void) { return MP_STATE_VM(sched_sp); }
-bool mp_sched_schedule(mp_obj_t function, mp_obj_t arg, void *carg);
+bool mp_sched_schedule_ex(mp_obj_t function, mp_obj_t arg, void *carg);
+inline bool mp_sched_schedule(mp_obj_t function, mp_obj_t arg)
+{
+    return mp_sched_schedule_ex(function, arg, NULL);
+}
 
 void free_carg(mp_sched_carg_t *carg);
 mp_sched_carg_t *make_carg_entry(mp_sched_carg_t *carg, int idx, uint8_t type, int val, const uint8_t *sval, const char *key);

--- a/MicroPython_BUILD/components/micropython/py/scheduler.c
+++ b/MicroPython_BUILD/components/micropython/py/scheduler.c
@@ -345,7 +345,7 @@ void mp_sched_unlock(void) {
 }
 
 //-------------------------------------------------------------------
-bool mp_sched_schedule(mp_obj_t function, mp_obj_t arg, void *carg) {
+bool mp_sched_schedule_ex(mp_obj_t function, mp_obj_t arg, void *carg) {
     mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
     bool ret;
     if (MP_STATE_VM(sched_sp) < MICROPY_SCHEDULER_DEPTH) {


### PR DESCRIPTION
This is important for compatability with libraries that call `mp_sched_schedule` and need to compile on both the original Microptython and lobo's Micropython. New prototype name changed to `mp_sched_schedule_ex`