### PR TITLE
Added support for ST7735 1.44" Greentab

### DIFF
--- a/MicroPython_BUILD/components/micropython/esp32/libs/tft/tftspi.c
+++ b/MicroPython_BUILD/components/micropython/esp32/libs/tft/tftspi.c
@@ -1251,6 +1251,12 @@ esp_err_t TFT_display_init(display_config_t *dconfig)
         commandList(Rcmd2green);
         commandList(Rcmd3);
     }
+    else if (tft_disp_type == DISP_TYPE_ST7735R144G) {
+        //ESP_LOGW(TAG, "Display type DISP_TYPE_ST7735R144G.");
+        commandList(STP7735R_init);
+        commandList(Rcmd2green144);
+        commandList(Rcmd3);
+    }
     else if (tft_disp_type == DISP_TYPE_ST7735B) {
         commandList(STP7735R_init);
         commandList(Rcmd2red);

--- a/MicroPython_BUILD/components/micropython/esp32/libs/tft/tftspi.h
+++ b/MicroPython_BUILD/components/micropython/esp32/libs/tft/tftspi.h
@@ -91,15 +91,16 @@ typedef struct __attribute__((__packed__)) {
 #define PORTRAIT_FLIP	2
 #define LANDSCAPE_FLIP	3
 
-#define DISP_TYPE_ILI9341	0
-#define DISP_TYPE_ILI9488	1
-#define DISP_TYPE_ST7789V	2
-#define DISP_TYPE_ST7735	3
-#define DISP_TYPE_ST7735R	4
-#define DISP_TYPE_ST7735B	5
-#define DISP_TYPE_M5STACK	6
-#define DISP_TYPE_GENERIC	7
-#define DISP_TYPE_MAX		8
+#define DISP_TYPE_ILI9341     0
+#define DISP_TYPE_ILI9488     1
+#define DISP_TYPE_ST7789V     2
+#define DISP_TYPE_ST7735      3
+#define DISP_TYPE_ST7735R     4
+#define DISP_TYPE_ST7735R144G 5 // ST7735 1.44" GREEN TAB
+#define DISP_TYPE_ST7735B     6
+#define DISP_TYPE_M5STACK     7
+#define DISP_TYPE_GENERIC     8
+#define DISP_TYPE_MAX         9
 
 #define DEFAULT_TFT_DISPLAY_WIDTH  240
 #define DEFAULT_TFT_DISPLAY_HEIGHT 320
@@ -484,7 +485,9 @@ static const uint8_t STP7735_init[] = {
 // Init for 7735R, part 1 (red or green tab)
 // --------------------------------------
 static const uint8_t  STP7735R_init[] = {
-  14,                       // 14 commands in list
+  15,                       // 15 commands in list
+  ST7735_SWRESET, TFT_CMD_DELAY, // 1: Software reset, 0 args, w/delay
+  150,                          // 150 ms delay
   ST7735_SLPOUT ,   TFT_CMD_DELAY,	//  2: Out of sleep mode, 0 args, w/delay
   255,						//     500 ms delay
   ST7735_FRMCTR1, 3      ,	//  3: Frame rate ctrl - normal mode, 3 args:
@@ -530,6 +533,18 @@ static const uint8_t Rcmd2green[] = {
   TFT_PASET  , 4      ,	    //  2: Row addr set, 4 args, no delay:
   0x00, 0x01,				//     XSTART = 0
   0x00, 0x9F+0x01			//     XEND = 160
+};
+
+// Init for 7735R, part 2 (green tab, 1.44")
+// -----------------------------------------
+static const uint8_t Rcmd2green144[] = {
+  2,                        // 2 commands in list:
+  TFT_CASET , 4 ,           // 1: Column addr set, 4 args, no delay:
+    0x00, 0x00,             //    XSTART = 2
+    0x00, 0x7F,             //    XEND   = 127
+  TFT_PASET , 4 ,           // 2: Row addr set, 4 args, no delay:
+    0x00, 0x00,             //    XSTART = 3
+    0x00, 0x7F,             //    XEND = 127 
 };
 
 // Init for 7735R, part 2 (red tab only)

--- a/MicroPython_BUILD/components/micropython/esp32/moddisplay_tft.c
+++ b/MicroPython_BUILD/components/micropython/esp32/moddisplay_tft.c
@@ -70,6 +70,7 @@ static const char* const display_types[] = {
     "ST7789V",
     "ST7735",
     "ST7735R",
+    "ST7735R144G",
     "ST7735B",
     "M5STACK",
     "Unknown",
@@ -109,8 +110,21 @@ STATIC void display_tft_printinfo(const mp_print_t *print, mp_obj_t self_in, mp_
     display_tft_obj_t *self = self_in;
     if (self->disp_spi->handle) {
         mp_printf(print, "TFT   (%dx%d, Type=%s, Ready: %s, Color mode: %d-bit, Clk=%u Hz, RdClk=%u Hz, Touch: %s)\n",
-                self->dconfig.width, self->dconfig.height, display_types[self->dconfig.type], ((self->disp_spi->handle) ? "yes" : "no"), self->dconfig.color_bits, self->dconfig.speed, self->dconfig.rdspeed, ((self->ts_spi->handle) ? "yes" : "no"));
-        mp_printf(print, "Pins  (miso=%d, mosi=%d, clk=%d, cs=%d, dc=%d, reset=%d, backlight=%d)", self->dconfig.miso, self->dconfig.mosi, self->dconfig.sck, self->dconfig.cs, self->dconfig.dc, self->dconfig.rst, self->dconfig.bckl);
+                self->dconfig.width, 
+                self->dconfig.height, 
+                display_types[self->dconfig.type], 
+               ((self->disp_spi->handle) ? "yes" : "no"), 
+                self->dconfig.color_bits, 
+                self->dconfig.speed, 
+                self->dconfig.rdspeed, ((self->ts_spi->handle) ? "yes" : "no"));
+        mp_printf(print, "Pins  (miso=%d, mosi=%d, clk=%d, cs=%d, dc=%d, reset=%d, backlight=%d)",                  self->dconfig.miso, 
+                  self->dconfig.mosi, 
+                  self->dconfig.sck, 
+                  self->dconfig.cs, 
+                  self->dconfig.dc, 
+                  self->dconfig.rst, 
+                  self->dconfig.bckl);
+
         if (self->ts_spi->handle) {
             mp_printf(print, "\nTouch (Enabled, type: %s, cs=%d)", touch_types[self->dconfig.touch], self->dconfig.tcs);
         }
@@ -261,6 +275,7 @@ STATIC mp_obj_t display_tft_init(mp_uint_t n_args, const mp_obj_t *pos_args, mp_
         if ((self->dconfig.type == DISP_TYPE_ST7789V) ||
                 (self->dconfig.type == DISP_TYPE_ST7735) ||
                 (self->dconfig.type == DISP_TYPE_ST7735R) ||
+                (self->dconfig.type == DISP_TYPE_ST7735R144G) ||
                 (self->dconfig.type == DISP_TYPE_ST7735B)) self->dconfig.invrot = 1;
         else if (self->dconfig.type == DISP_TYPE_M5STACK) self->dconfig.invrot = 3;
         else self->dconfig.invrot = 0;
@@ -1632,6 +1647,7 @@ STATIC const mp_rom_map_elem_t display_tft_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_ILI9488),             MP_ROM_INT(DISP_TYPE_ILI9488) },
     { MP_ROM_QSTR(MP_QSTR_ST7735),              MP_ROM_INT(DISP_TYPE_ST7735) },
     { MP_ROM_QSTR(MP_QSTR_ST7735R),             MP_ROM_INT(DISP_TYPE_ST7735R) },
+    { MP_ROM_QSTR(MP_QSTR_ST7735R144G),         MP_ROM_INT(DISP_TYPE_ST7735R144G) },
     { MP_ROM_QSTR(MP_QSTR_ST7735B),             MP_ROM_INT(DISP_TYPE_ST7735B) },
     { MP_ROM_QSTR(MP_QSTR_M5STACK),             MP_ROM_INT(DISP_TYPE_M5STACK) },
     { MP_ROM_QSTR(MP_QSTR_GENERIC),             MP_ROM_INT(DISP_TYPE_GENERIC) },


### PR DESCRIPTION
Hello. I added support for the 1.44" 128x128 Greentab displays.
The offset isn't perfect, but using setwin it works out fine.